### PR TITLE
Bugfix 레시피 없을 때 문구 추가, 상세페이지 전체 음료량 표시

### DIFF
--- a/src/components/recipeDetail/element/RecipeDescBody.jsx
+++ b/src/components/recipeDetail/element/RecipeDescBody.jsx
@@ -13,6 +13,7 @@ const RecipeDescBody = (props) => {
     updatedAt,
     resizedUrl,
     imageUrl,
+    cupSize,
     nickname,
   } = recipe;
 
@@ -35,6 +36,9 @@ const RecipeDescBody = (props) => {
   return (
     <StRecipeDescBody>
       <ul className="text_desc">
+        <li>
+          <strong>전체 : {cupSize}ml</strong>
+        </li>
         {ingredientList.map((list, i) => (
           <li key={"text_desc" + i}>
             {list.ingredientName} : {list.ingredientAmount}ml
@@ -73,6 +77,10 @@ const StRecipeDescBody = styled.div`
   gap: 25px;
 
   font-size: 12px;
+
+  strong {
+    font-weight: 500;
+  }
 
   .user_info {
     display: flex;

--- a/src/components/recipeEdit/RecipeEditWrap.jsx
+++ b/src/components/recipeEdit/RecipeEditWrap.jsx
@@ -58,9 +58,7 @@ const RecipeEditForm = (props) => {
     let newContent = content;
 
     if (data.title === "" && data.content === "") {
-      navigate(`/recipe/${recipeId}/detail`, {
-        state: { message: "레시피가\n 저장되었습니다." },
-      });
+      navigate(`/recipe/${recipeId}/detail`);
       return;
     }
 

--- a/src/components/recipeMypage/element/RecipeSilder.jsx
+++ b/src/components/recipeMypage/element/RecipeSilder.jsx
@@ -52,7 +52,7 @@ const RecipeList = (props) => {
   return (
     <>
       <StSlider {...settings}>
-        {!recipeList && <h3 className="list_empty">레시피가 없습니다.</h3>}
+        {recipeList && <h3 className="list_empty">레시피가 없습니다.</h3>}
 
         {recipeList?.map((recipe, i) => {
           return (
@@ -147,6 +147,8 @@ const StSlider = styled(Slider)`
   }
 
   .list_empty {
+    margin-top: 50px;
+
     text-align: center;
     color: #cdcdcd;
   }

--- a/src/components/recipeMypage/element/RecipeSilder.jsx
+++ b/src/components/recipeMypage/element/RecipeSilder.jsx
@@ -52,6 +52,8 @@ const RecipeList = (props) => {
   return (
     <>
       <StSlider {...settings}>
+        {!recipeList && <h3 className="list_empty">레시피가 없습니다.</h3>}
+
         {recipeList?.map((recipe, i) => {
           return (
             // Slider의 자식은 inline-block
@@ -142,6 +144,11 @@ const StSlider = styled(Slider)`
     height: 40vh;
 
     background-color: #aaa;
+  }
+
+  .list_empty {
+    text-align: center;
+    color: #cdcdcd;
   }
 `;
 


### PR DESCRIPTION
**PR** : 
- 레시피 없을 때 문구 추가
```jsx
{!recipeList && <h3 className="list_empty">레시피가 없습니다.</h3>}
```
![image](https://user-images.githubusercontent.com/94776135/191955924-6dc93de5-2646-4cfe-8406-724729ce9e6f.png)

- 상세페이지 전체 음료량 표시
![image](https://user-images.githubusercontent.com/94776135/191955553-be470b36-aa14-4298-a059-0c8051d4423b.png)
