### PR TITLE
Bugfix 이전버튼 작동 버그, 재료 취소 버튼 위치, 글자수 제한

### DIFF
--- a/src/components/recipeCreate/RecipeCreateNavigation.jsx
+++ b/src/components/recipeCreate/RecipeCreateNavigation.jsx
@@ -12,24 +12,37 @@ import ToastMessage from "../elements/modal/ToastMessage";
 import ConfirmBox from "../elements/modal/ConfirmBox";
 
 const RecipeCreateNavigation = (props) => {
-	const { cupState, setCupState, stepState, setStepState, formProps, recipeCreated} = props;
-  const { ingredientDeleteMode, cupFull, currCupSize:cupSize, isIcedTag, currentIngredientDeleted} = cupState
-  const { step, finalStep, subStep, finalSubStep } = stepState
-  const { watch, getValues, reset } = formProps
-  
+  const {
+    cupState,
+    setCupState,
+    stepState,
+    setStepState,
+    formProps,
+    recipeCreated,
+  } = props;
+  const {
+    ingredientDeleteMode,
+    cupFull,
+    currCupSize: cupSize,
+    isIcedTag,
+    currentIngredientDeleted,
+  } = cupState;
+  const { step, finalStep, subStep, finalSubStep } = stepState;
+  const { watch, getValues, reset } = formProps;
+
   // const buttonDone = useRef();
 
-  const [modalCupFullRequired, setModalCupFullRequired] = useState(false)
-  const [needMoreIngredient, setNeedMoreIngredient] = useState(false)
-  const [showComfirmBox, setShowComfirmBox] = useState(false)
-  const [showCompleteRequireBox, setShowCompleteRequireBox] = useState(false)
+  const [modalCupFullRequired, setModalCupFullRequired] = useState(false);
+  const [needMoreIngredient, setNeedMoreIngredient] = useState(false);
+  const [showComfirmBox, setShowComfirmBox] = useState(false);
+  const [showCompleteRequireBox, setShowCompleteRequireBox] = useState(false);
 
-  window.addEventListener('keydown', ()=>{
+  window.addEventListener("keydown", () => {
     if (event.keyCode === 13) {
       event.preventDefault();
     }
-  })
-  
+  });
+
   // State 초기화할 때 사용합니다.
   const initialCupState = {
     cupStyleHeight: 0,
@@ -42,11 +55,11 @@ const RecipeCreateNavigation = (props) => {
     ingredientDeleteMode: false,
     currentIngredientDeleted: false,
     currIngredientList: [],
-  }
+  };
   const initialStepState = {
     step: 0,
-    subStep: 0
-  }
+    subStep: 0,
+  };
 
   /***********************************/
   /* 레시피 만들기 step 상태 관리 변수 */
@@ -56,63 +69,66 @@ const RecipeCreateNavigation = (props) => {
   const stepEnd = step === finalStep;
   const subStep0 = subStep === 0;
   const subStepEnd = subStep === finalSubStep;
-  
+
   /******************************/
   /* 재료 리스트 validation 관리  */
   /* undefined일 때 거르는 조건문 */
   /******************************/
-  const newList = getValues('ingredientList')
-  const newListExist = newList !== undefined
+  const newList = getValues("ingredientList");
+  const newListExist = newList !== undefined;
 
   let nameRequired = false;
   let amountRequired = false;
   let colorRequired = true;
 
-  if(newListExist){
+  if (newListExist) {
     // 이름이 존재, 필요 여부
-    const ingredientNameExist = newList[newList.length-1]?.ingredientName !== undefined
-    if(ingredientNameExist){
-      const ingredientName = newList[newList.length-1]?.ingredientName
-      ingredientName === '' ? nameRequired = true : '';
+    const ingredientNameExist =
+      newList[newList.length - 1]?.ingredientName !== undefined;
+    if (ingredientNameExist) {
+      const ingredientName = newList[newList.length - 1]?.ingredientName;
+      ingredientName === "" ? (nameRequired = true) : "";
     }
-    
+
     // 재료량이 존재, 필요 여부
-    const ingredientAmountExist = +newList[newList.length-1]?.ingredientAmount === 0 || +newList[newList.length-1]?.ingredientAmount < 10
-    if(ingredientAmountExist) amountRequired = true
-    
+    const ingredientAmountExist =
+      +newList[newList.length - 1]?.ingredientAmount === 0 ||
+      +newList[newList.length - 1]?.ingredientAmount < 10;
+    if (ingredientAmountExist) amountRequired = true;
+
     // 색깔 선택 필요 여부
-    colorRequired = newList[newList.length-1]?.ingredientColor === null
+    colorRequired = newList[newList.length - 1]?.ingredientColor === null;
   }
 
   /****************************************/
-  /**** "레시피 텍스트 value 입력 확인"  ****/ 
+  /**** "레시피 텍스트 value 입력 확인"  ****/
   /****************************************/
   const newInput = watch();
-  let recipeCompletedRequired = true
-  if(newInput.title?.length > 0 && newInput.content?.length >0){
-    recipeCompletedRequired ? recipeCompletedRequired = false : '';
+  let recipeCompletedRequired = true;
+  if (newInput.title?.length > 0 && newInput.content?.length > 0) {
+    recipeCompletedRequired ? (recipeCompletedRequired = false) : "";
   } else {
-    !recipeCompletedRequired ? recipeCompletedRequired = true : '';
+    !recipeCompletedRequired ? (recipeCompletedRequired = true) : "";
   }
 
   /*********************************/
-  /**** "재료 처음부터 추가하기"  ****/ 
+  /**** "재료 처음부터 추가하기"  ****/
   /** 재료 처음부터 만들기 Confirmed */
   const goFirstConfirmed = () => {
-    setShowComfirmBox(false)
-    setTimeout(()=>{
-      reset()
-      setCupState(initialCupState)
-      setStepState(prev => ({...prev, ...initialStepState}))
-    }, 1000)
-  }
-  
+    setShowComfirmBox(false);
+    setTimeout(() => {
+      reset();
+      setCupState(initialCupState);
+      setStepState((prev) => ({ ...prev, ...initialStepState }));
+    }, 1000);
+  };
+
   /** 재료 처음부터 만들기 Denied */
   const goFirstDenied = () => {
-    setTimeout(()=>{
-      setShowComfirmBox(false)
-    }, 1000)
-  }
+    setTimeout(() => {
+      setShowComfirmBox(false);
+    }, 1000);
+  };
 
   /*************************/
   /** 버튼 비활성화 config **/
@@ -123,26 +139,26 @@ const RecipeCreateNavigation = (props) => {
     subStep0: step2 && subStep0,
     subStep1NameRequired: subStep === 1 && nameRequired,
     subStep2AmountRequired: subStep === 2 && amountRequired,
-    subStep3ColorRequired: subStep === 3 && colorRequired
-  }
+    subStep3ColorRequired: subStep === 3 && colorRequired,
+  };
   const prevButtonDisableCaseObj = {
     currentIngredientDeleted: step2 && currentIngredientDeleted,
-  }
-  
+  };
+
   console.log(subStep === 3, colorRequired);
 
-  let nextDisabled // next 버튼 컴포넌트 disabled={} 속성에 넘길 값
-  for (const x in nextButtonDisableCaseObj){
-    nextButtonDisableCaseObj[x] ? nextDisabled = true : '';
+  let nextDisabled; // next 버튼 컴포넌트 disabled={} 속성에 넘길 값
+  for (const x in nextButtonDisableCaseObj) {
+    nextButtonDisableCaseObj[x] ? (nextDisabled = true) : "";
   }
-  
-  let prevDisabled // prev 버튼 컴포넌트 disabled={} 속성에 넘길 값
-  for (const x in prevButtonDisableCaseObj){
-    prevButtonDisableCaseObj[x] ? prevDisabled = true : '';
+
+  let prevDisabled; // prev 버튼 컴포넌트 disabled={} 속성에 넘길 값
+  for (const x in prevButtonDisableCaseObj) {
+    prevButtonDisableCaseObj[x] ? (prevDisabled = true) : "";
   }
 
   // cupNotFull: 버튼 css 비활성화처럼 스타일링
-  let buttonDisableStyle = step === 2 && !(subStepEnd && cupFull)
+  let buttonDisableStyle = step === 2 && !(subStepEnd && cupFull);
 
   //*********************************//
   //***  Step 이동하는 함수: 총 4개 ***//
@@ -150,20 +166,24 @@ const RecipeCreateNavigation = (props) => {
 
   /** 다음 step으로 이동 */
   const goNextStep = () => {
-    step < finalStep + 1 ? setStepState(prev => ({...prev, step: prev.step + 1})) : '';
-  }
+    step < finalStep + 1
+      ? setStepState((prev) => ({ ...prev, step: prev.step + 1 }))
+      : "";
+  };
   /** 이전 step으로 이동 */
   const goPrevStep = () => {
-    step > 0 && setStepState(prev => ({...prev, step: prev.step - 1}));
-  }
+    step > 0 && setStepState((prev) => ({ ...prev, step: prev.step - 1 }));
+  };
   /** 다음 step으로 이동 */
   const goNextSubStep = () => {
-    subStep < finalSubStep &&  setStepState(prev => ({...prev, subStep: prev.subStep + 1}));
-  }
+    subStep < finalSubStep &&
+      setStepState((prev) => ({ ...prev, subStep: prev.subStep + 1 }));
+  };
   /** 이전 step으로 이동 */
   const goPrevSubStep = () => {
-    subStep > 0 && setStepState(prev => ({...prev, subStep: prev.subStep - 1}));
-  }
+    subStep > 0 &&
+      setStepState((prev) => ({ ...prev, subStep: prev.subStep - 1 }));
+  };
 
   //*********************************//
   //***  버튼 클릭 핸들러: 총 4개   ***//
@@ -173,144 +193,148 @@ const RecipeCreateNavigation = (props) => {
   const stepButtonPrevClickHandler = () => {
     switch (step) {
       case 2:
-        setShowComfirmBox(true)
+        setShowComfirmBox(true);
         return null;
-      default: '';
+      default:
+        "";
     }
-    goPrevStep()
-  }
+    goPrevStep();
+  };
 
   /** 다음 step 버튼 클릭 핸들러 */
   const stepButtonNextClickHandler = () => {
     switch (step) {
       case 2:
-        if(!cupFull) {
-          setModalCupFullRequired(true)
-          setTimeout(()=>{
-            setModalCupFullRequired(false)
-          }, 2000)
+        if (!cupFull) {
+          setModalCupFullRequired(true);
+          setTimeout(() => {
+            setModalCupFullRequired(false);
+          }, 2000);
           return;
-        } 
+        }
         break;
       case 3:
-        if(watch('title')?.length === 0 || watch('content').length === 0 ) return;
-        setCupState({...cupState, subStep: 0})
+        if (watch("title")?.length === 0 || watch("content").length === 0)
+          return;
+        setCupState({ ...cupState, subStep: 0 });
         return;
-      default: '';
+      default:
+        "";
     }
     goNextStep();
-  }
-  
+  };
+
   /** 이전 subStep 버튼 클릭 핸들러 */
   const subStepButtonPrevClickHandler = () => {
-    console.log(currentIngredientDeleted);
+    console.log(currentIngredientDeleted, subStep);
     switch (subStep) {
       case 1:
-        setShowComfirmBox(true)
-        return null
+        setShowComfirmBox(true);
+        return null;
       case 4:
-        if(currentIngredientDeleted){
-          setNeedMoreIngredient(true)
-          setTimeout(()=>{
-            setNeedMoreIngredient(false)
-          }, 2000)
+        if (currentIngredientDeleted) {
+          setNeedMoreIngredient(true);
+          setTimeout(() => {
+            setNeedMoreIngredient(false);
+          }, 2000);
+          return null;
         }
-        return null
-      default: ''
+      default:
+        "";
     }
     goPrevSubStep();
-  }
-  
+  };
+
   /** 다음 subStep 버튼 클릭 핸들러  */
   const subStepButtonNextClickHandler = () => {
-    goNextSubStep()
-  }
-  
+    goNextSubStep();
+  };
+
   /** 완료 Done 버튼 클릭 핸들러  */
   const doneButtonNextClickHandler = () => {
-    if(recipeCompletedRequired){
-      setShowCompleteRequireBox(true)
-      setTimeout(()=>{
-        setShowCompleteRequireBox(false)
-      }, 2000)
+    if (recipeCompletedRequired) {
+      setShowCompleteRequireBox(true);
+      setTimeout(() => {
+        setShowCompleteRequireBox(false);
+      }, 2000);
     }
-  }
+  };
 
-	return (
-		<Navigation empty={true}>
-      {!ingredientDeleteMode && 
+  return (
+    <Navigation empty={true}>
+      {!ingredientDeleteMode && (
         <>
-          {step0 &&
-            <NavButtonGoMain />
-          }
+          {step0 && <NavButtonGoMain />}
 
-          {!step0 &&
-            !(step2 && !subStep0) &&
+          {!step0 && !(step2 && !subStep0) && (
             <NavButtonPrevLevel onClick={stepButtonPrevClickHandler} />
-          }
+          )}
 
-          {(step2 && !subStep0) &&
+          {step2 && !subStep0 && (
             <NavButtonPrevSublevel
-              disabledStyle={prevDisabled} 
-              onClick={subStepButtonPrevClickHandler} 
+              disabledStyle={prevDisabled}
+              onClick={subStepButtonPrevClickHandler}
             />
-          }
+          )}
 
-          {!stepEnd &&
-            !(step2 && !subStepEnd) &&
-            <NavButtonNextLevel 
-              disabled={nextDisabled} 
-              onClick={stepButtonNextClickHandler} 
+          {!stepEnd && !(step2 && !subStepEnd) && (
+            <NavButtonNextLevel
+              disabled={nextDisabled}
+              onClick={stepButtonNextClickHandler}
               disabledStyle={buttonDisableStyle}
             />
-          }
+          )}
 
-          {(step2 && !subStepEnd) &&
-            <NavButtonNextSublevel 
-              disabled={nextDisabled} 
-              onClick={subStepButtonNextClickHandler} 
+          {step2 && !subStepEnd && (
+            <NavButtonNextSublevel
+              disabled={nextDisabled}
+              onClick={subStepButtonNextClickHandler}
             />
-          }
+          )}
 
-          {stepEnd &&
+          {stepEnd && (
             <NavButtonDone
               disabled={recipeCreated}
               disabledStyle={recipeCompletedRequired}
               onClick={doneButtonNextClickHandler}
             />
-          }
+          )}
 
-          <h4 className="title">레시피 만들기</h4>
+          <h4
+            className="title"
+            onClick={() => {
+              setShowComfirmBox(true);
+            }}
+          >
+            레시피 만들기
+          </h4>
 
           {/* 모달 리스트 */}
-          {modalCupFullRequired && 
+          {modalCupFullRequired && (
             <ToastMessage
-              text={'재료를 전부 채우지 않으면\n다음 단계로 넘어갈 수 없어요!'}
-            />  
-          }
-          {showCompleteRequireBox && 
-            <ToastMessage
-              text={'레시피 내용을\n완성해주세요!'}
-            />  
-          }
-          {needMoreIngredient && 
-            <ToastMessage
-              text={'새로운 재료를\n추가 해주세요!'}
-            />  
-          }
-          {showComfirmBox && 
+              text={"재료를 전부 채우지 않으면\n다음 단계로 넘어갈 수 없어요!"}
+            />
+          )}
+          {showCompleteRequireBox && (
+            <ToastMessage text={"레시피 내용을\n완성해주세요!"} />
+          )}
+          {needMoreIngredient && (
+            <ToastMessage text={"새로운 재료를\n추가 해주세요!"} />
+          )}
+          {showComfirmBox && (
             <ConfirmBox
-              text={'지금 이전 버튼을 누를 시\n전체량 선택부터 새로 하셔야 합니다.'}
-              confirmButtonText={'새로하기'}
+              text={
+                "지금 이전 버튼을 누를 시\n전체량 선택부터 새로 하셔야 합니다."
+              }
+              confirmButtonText={"새로하기"}
               onComfirmed={goFirstConfirmed}
               onDenied={goFirstDenied}
             />
-          }
+          )}
         </>
-      }
-      
-		</Navigation>
-	)
-}
+      )}
+    </Navigation>
+  );
+};
 
 export default RecipeCreateNavigation;

--- a/src/components/recipeCreate/element/RecipeCreateModal.jsx
+++ b/src/components/recipeCreate/element/RecipeCreateModal.jsx
@@ -1,31 +1,30 @@
 import styled from "styled-components";
 
-import cancel from '../../../assets/svg/cancel_ingredient.svg'
+import cancel from "../../../assets/svg/cancel_ingredient.svg";
 
 const RecipeCreateModal = (props) => {
-  const {setCupState, onClick} = props;
+  const { setCupState, onClick } = props;
 
   return (
     <StModal
-      onClick={()=>{
-        setCupState(prev => ({...prev, ingredientDeleteMode: false}))
-        document.querySelector('.ingredientSelected').classList.remove('ingredientSelected')
+      onClick={() => {
+        setCupState((prev) => ({ ...prev, ingredientDeleteMode: false }));
+        document
+          .querySelector(".ingredientSelected")
+          .classList.remove("ingredientSelected");
       }}
     >
-      <span 
-        className="button_close"
-      >
-        취소
-      </span>
-      <img 
-        src={cancel} 
+      <div className="contents_area">
+        <span className="button_close">취소</span>
+      </div>
+      <img
+        src={cancel}
         onClick={onClick}
-        className={'ingredient_button'}
-        alt="재료 삭제 버튼" 
+        className={"ingredient_button"}
+        alt="재료 삭제 버튼"
       />
-
     </StModal>
-  )
+  );
 };
 
 export default RecipeCreateModal;
@@ -33,45 +32,55 @@ export default RecipeCreateModal;
 const StModal = styled.div`
   width: 100vw;
   height: 100vh;
-  
+
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   position: fixed;
   top: 0;
   left: 0;
   z-index: 99999999;
-  
+
   background: rgba(0, 0, 0, 0.3);
+
+  .contents_area {
+    flex: 0 1 600px;
+    height: 100%;
+    position: relative;
+  }
 
   .ingredient_button {
     position: fixed;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%) rotate(0deg);
-    
+
     transform-origin: 48% 48%;
     z-index: 999;
 
-    animation: buttonShow .5s forwards;
+    animation: buttonShow 0.5s forwards;
   }
 
   @keyframes buttonShow {
-    0% {transform: translate(-50%, -60%) rotate(45deg); 
-    opacity: 0;}
-    100% {transform: translate(-50%, -60%) rotate(0deg); 
-    opacity: 1;}
+    0% {
+      transform: translate(-50%, -60%) rotate(45deg);
+      opacity: 0;
+    }
+    100% {
+      transform: translate(-50%, -60%) rotate(0deg);
+      opacity: 1;
+    }
   }
 
   .button_close {
     position: absolute;
     top: 1.2rem;
     left: 1.5rem;
-  
+
     color: #fff;
-    
+
     font-size: 1.4rem;
     font-weight: 700;
   }
-`
+`;

--- a/src/components/recipeCreate/element/RecipeIngredient.jsx
+++ b/src/components/recipeCreate/element/RecipeIngredient.jsx
@@ -4,27 +4,27 @@ import RecipeIngredientColorLists from "./RecipeIngredientColorLists";
 import styled from "styled-components";
 
 const RecipeIngredient = (props) => {
-  const { idx, calcAmount, cupState, setCupState, stepState, formProps } = props;
-  const {subStep} = stepState;
-  const {register, watch} = formProps;
+  const { idx, calcAmount, cupState, setCupState, stepState, formProps } =
+    props;
+  const { subStep } = stepState;
+  const { register, watch } = formProps;
 
   return (
     <StRecipeIngredient>
-      {subStep === 1 &&
+      {subStep === 1 && (
         <>
-          <div className="info_box_center">
-            재료의 이름은 무엇인가요?
-          </div>
-          <input 
-            type="text" 
+          <div className="info_box_center">재료의 이름은 무엇인가요?</div>
+          <input
+            type="text"
             required={true}
             placeholder={`재료`}
             {...register(`ingredientList.${idx}.ingredientName`)}
+            maxLength={20}
           />
         </>
-      }
+      )}
 
-      {subStep === 2 &&
+      {subStep === 2 && (
         <>
           <div className="info_box_center">
             재료량을 입력해주세요.(최소 10ml)
@@ -32,34 +32,30 @@ const RecipeIngredient = (props) => {
           <div className="flex_box">
             <RecipeIngredientNumber
               idx={idx}
-              formProps={formProps}    
+              formProps={formProps}
               calcAmount={calcAmount}
-              />
+            />
             ml
           </div>
         </>
-      }
+      )}
 
-      {subStep === 3 &&
+      {subStep === 3 && (
         <>
-          <div className="info_box_center">
-            재료색을 선택해주세요.
-          </div>
-          
-          <RecipeIngredientColorLists 
-            idx={idx}
-            formProps={formProps}
-          />
+          <div className="info_box_center">재료색을 선택해주세요.</div>
+
+          <RecipeIngredientColorLists idx={idx} formProps={formProps} />
         </>
-      }
+      )}
     </StRecipeIngredient>
-	)
-}
+  );
+};
 
 export default RecipeIngredient;
 
 const StRecipeIngredient = styled.div`
-  input, select {
+  input,
+  select {
     all: unset;
     width: 100%;
 
@@ -80,7 +76,7 @@ const StRecipeIngredient = styled.div`
     display: flex;
     gap: 20px;
   }
-`
+`;
 
 const StColorCircleBox = styled.div`
   display: flex;
@@ -95,11 +91,11 @@ const StColorCircleBox = styled.div`
   }
 
   label {
-    transition: all .2s;
+    transition: all 0.2s;
   }
-  
+
   input:checked + .colorLabel {
     box-shadow: 0 2px 7px 3px rgba(45, 35, 53, 0.1);
     transform: translateY(-2px) scale(1.1);
   }
-`
+`;

--- a/src/components/recipeCreate/element/RecipeInput.jsx
+++ b/src/components/recipeCreate/element/RecipeInput.jsx
@@ -1,14 +1,21 @@
 import styled from "styled-components";
 
-const RecipeInput = ({ label, type="text", placeholder="", register, config={}}) => {
-	return (
-			<StInput 
-        type={ type } 
-        placeholder={placeholder}
-				{...register( label, config )} 
-			/>
-	)
-}
+const RecipeInput = ({
+  label,
+  type = "text",
+  placeholder = "",
+  register,
+  config = {},
+}) => {
+  return (
+    <StInput
+      type={type}
+      placeholder={placeholder}
+      {...register(label, config)}
+      maxLength={20}
+    />
+  );
+};
 
 export default RecipeInput;
 
@@ -24,4 +31,4 @@ const StInput = styled.input`
   font-size: 1.2rem;
   font-weight: 500;
   line-height: 1.6;
-`
+`;

--- a/src/components/recipeCreate/element/RecipeTextarea.jsx
+++ b/src/components/recipeCreate/element/RecipeTextarea.jsx
@@ -1,17 +1,23 @@
 import styled from "styled-components";
 
-const RecipeTextarea = ({ name, placeholder="", rows=8, register, config={} }) => {
-	return (
-    <StTextarea 
+const RecipeTextarea = ({
+  name,
+  placeholder = "",
+  rows = 8,
+  register,
+  config = {},
+}) => {
+  return (
+    <StTextarea
       type="textarea"
       rows={rows}
       maxLength={255}
       minLength={3}
       placeholder={placeholder}
-      {...register( name, config )} 
+      {...register(name, config)}
     />
-	)
-}
+  );
+};
 
 export default RecipeTextarea;
 
@@ -27,4 +33,7 @@ const StTextarea = styled.textarea`
   font-size: 1.2rem;
   font-weight: 500;
   line-height: 1.6;
-`
+
+  white-space: normal;
+  word-break: break-all;
+`;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -28,6 +28,19 @@ const Login = () => {
   const [pwFailure, setPwFailure] = useState(false);
   const [check, setCheck] = useState(false);
   const [loginError, setLoginError] = useState(false);
+
+  const [messageModal, setMessageModal] = useState(false);
+  const messageText = location.state?.message;
+
+  useEffect(() => {
+    if (messageText !== undefined) {
+      setMessageModal(true);
+      setTimeout(() => {
+        setMessageModal(false);
+      }, 1500);
+    }
+  }, []);
+
   const onSubmit = async (data) => {
     console.log(data);
     // const data = { email: watch("email"), password: watch("password") };
@@ -123,6 +136,7 @@ const Login = () => {
       {loginError && (
         <ToastMessage text={errors?.loginError?.message} timer={1000} />
       )}
+      {messageModal && <ToastMessage text={messageText} timer={1500} />}
 
       {/* 로그인 시작 */}
       <StTitle>

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -17,6 +17,7 @@ const Mypage = () => {
   const token = localStorage.getItem("refreshToken");
   const { decodedToken } = useJwt(token);
   let userData = decodedToken;
+
   useEffect(() => {
     if (messageText !== undefined) {
       setMessageModal(true);

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -6,7 +6,7 @@ import illustration05 from "../assets/image/illustration/illustration05.png";
 import styled from "styled-components";
 
 const NotFound = (props) => {
-  const { message = "", timer = 1000 } = props;
+  const { message = "", timer = 1500 } = props;
   const navigate = useNavigate();
   const refreshToken = localStorage.getItem("refreshToken");
 
@@ -21,7 +21,7 @@ const NotFound = (props) => {
   return (
     <StWrap>
       <img src={illustration05} alt="커픽" />
-      <h4>{message ? message : "페이지를 찾을 수 없습니다."}</h4>
+      <h4>{message ? message : "페이지가 없거나 접근할 수 없습니다."}</h4>
       <p>
         {message ? (
           <button

--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
-import { useJwt } from "react-jwt";
 
 import Comments from "../pages/Comments";
 import Login from "../pages/Login";
@@ -53,17 +52,20 @@ const Router = () => {
       !loggedIn ? setLoggedIn(true) : "";
     } else {
       loggedIn ? setLoggedIn(false) : "";
+      navigate("/sign-in");
     }
+  }, [pathname]);
 
+  useEffect(() => {
     // 리디렉션: 로그인 필요한 페이지에서 토큰이 만료 되었을 때 작동
     if (!pathNeedLoggedIn) {
-      if (loggedIn) {
+      if (loggedIn && !refreshToken) {
         navigate("/sign-in", {
           state: { message: "자동으로 \n 로그아웃 되었습니다." },
         });
       }
     }
-  }, [pathname]);
+  }, [loggedIn]);
 
   return (
     <Routes>
@@ -103,19 +105,6 @@ const Router = () => {
           <Route path="/mypage" element={<Mypage />} />
           <Route path="/profile/edit" element={<ProfileEdit />} />
           <Route path="/recipe/:recipeId/edit" element={<RecipeEdit />} />
-
-          {caseNoLoggedIn.map((path, idx) => (
-            <Route
-              key={"routePathLogout" + idx}
-              path={path}
-              element={
-                <NotFound
-                  timer={30000}
-                  message={"로그아웃이 필요한 페이지입니다."}
-                />
-              }
-            />
-          ))}
         </>
       )}
 


### PR DESCRIPTION
**PR** : 
- [x] 레시피 작성 페이지 뒤로가기 버튼 이상함 <<<< 전체 확인 필요
  - [x] 음료 만들기 완료하고 레시피에 대한 것을 적는 페이지에서 이전 버튼을 눌렀을 시
         이전 버튼이 실행이 안됨
  - [x] subStep 4 재료 선택 후 뒤로가기 버튼 수정(리턴이 if문 바깥으로 나와있어서 실행이 안 되었음)
```jsx
case 4:
  if (currentIngredientDeleted) {
    setNeedMoreIngredient(true);
    setTimeout(() => {
      setNeedMoreIngredient(false);
    }, 2000);
    return null;
  }
```
- [x] 재료 삭제 모드일 때 취소 버튼 위치 <- max-width 600 안쪽으로
  - contents_area 감쌈
```jsx 
.contents_area {
  flex: 0 1 600px;
  height: 100%;
  position: relative;
}
```


![image](https://user-images.githubusercontent.com/94776135/192115907-eebc9db7-4b37-4b41-a49b-2fbc93c06d31.png)
