### PR TITLE
Bugfix 비로그인 막힌 버그 수정

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useLocation, useNavigate } from "react-router-dom";
 

--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -51,8 +51,10 @@ const Router = () => {
     if (refreshToken) {
       !loggedIn ? setLoggedIn(true) : "";
     } else {
-      loggedIn ? setLoggedIn(false) : "";
-      navigate("/sign-in");
+      if (loggedIn) {
+        setLoggedIn(false);
+        navigate("/sign-in");
+      }
     }
   }, [pathname]);
 


### PR DESCRIPTION
**PR** : 
- 토큰 관련 버그 수정 후 이어서 발생한, 비로그인 막힌 버그 수정

- pathname이 바뀌었을 때, 리프레시 토큰이 없다면 로그인 안 한 상태
로그인이 되어 있다면 로그아웃 상태로 바꾸고 /sigin-in으로 이동한다.
하단 코드로 수정!
```jsx
useEffect(() => {
  // 로그인 확인(refreshToken 유무)
  if (refreshToken) {
    !loggedIn ? setLoggedIn(true) : "";
  } else {
    if (loggedIn) {
      setLoggedIn(false);
      navigate("/sign-in");
    }
  }
}, [pathname]);
```

![image](https://user-images.githubusercontent.com/94776135/192116289-02dc8af5-d136-4e0f-bc8b-137759a7c932.png)
