### PR TITLE
Bugfix 로딩 시 푸터 위치, 깜박이는 버그 수정

### DIFF
--- a/src/partial/Footer.jsx
+++ b/src/partial/Footer.jsx
@@ -44,35 +44,37 @@ const Footer = ({ pathname }) => {
 
   return (
     <CustomFooter>
-      <CustomFooterButton onClick={goToMain}>
-        <div className={pathCommunity ? "svg_box on" : "svg_box"}>
-          <Icon01 />
-        </div>
-      </CustomFooterButton>
+      <div className="contents_area">
+        <CustomFooterButton onClick={goToMain}>
+          <div className={pathCommunity ? "svg_box on" : "svg_box"}>
+            <Icon01 />
+          </div>
+        </CustomFooterButton>
 
-      {/* <CustomFooterButton onClick={goToMain}>
+        {/* <CustomFooterButton onClick={goToMain}>
         <div className={pathname === "/recipe" ? "svg_box on" : "svg_box"}>
           <Icon02 />
         </div>
       </CustomFooterButton> */}
 
-      <CustomFooterButton onClick={goToCreate}>
-        <div className={pathRecipeCreate ? "svg_box on" : "svg_box"}>
-          <Icon03 />
-        </div>
-      </CustomFooterButton>
+        <CustomFooterButton onClick={goToCreate}>
+          <div className={pathRecipeCreate ? "svg_box on" : "svg_box"}>
+            <Icon03 />
+          </div>
+        </CustomFooterButton>
 
-      {/* <CustomFooterButton onClick={goToCreate}>
+        {/* <CustomFooterButton onClick={goToCreate}>
         <div className={pathname === "/recipe" ? "svg_box on" : "svg_box"}>
           <Icon04 />
         </div>
       </CustomFooterButton> */}
 
-      <CustomFooterButton onClick={goToMypage}>
-        <div className={pathMypage ? "svg_box on" : "svg_box"}>
-          <Icon05 />
-        </div>
-      </CustomFooterButton>
+        <CustomFooterButton onClick={goToMypage}>
+          <div className={pathMypage ? "svg_box on" : "svg_box"}>
+            <Icon05 />
+          </div>
+        </CustomFooterButton>
+      </div>
     </CustomFooter>
   );
 };

--- a/src/styles/customLayoutStyle.js
+++ b/src/styles/customLayoutStyle.js
@@ -144,9 +144,17 @@ const CustomFooter = styled.footer`
   ${({ theme }) => {
     return css`
       height: 9rem;
-
-      display: flex;
       position: relative;
+
+      .contents_area {
+        width: 100%;
+        height: 9rem;
+
+        display: flex;
+
+        position: fixed;
+        bottom: 0;
+      }
 
       .svg_box {
         transition: all 0.2s;


### PR DESCRIPTION
**PR** : 
- 로딩 시 푸터 위치, 깜박이는 버그 수정
- 페이지를 로딩하며 화면 깜박일 때, 푸터 위치가 상단에서 => 하단으로 움직이며 화면이 깨져보이는 현상 수정했습니다.
- 푸터에 contents_area를 추가하고, fixed로 붙임(customElement내용 수정)
  => 기존 영역높이 유지하면서 하단에서 로딩되도록 하였습니다.

```
src\partial\Footer.jsx
src\styles\customLayoutStyle.js
```
