### PR TITLE
Style 마이페이지의 리스트, 시안에 맞게 수정

### DIFF
--- a/src/components/recipeMypage/element/RecipeSilder.jsx
+++ b/src/components/recipeMypage/element/RecipeSilder.jsx
@@ -81,12 +81,8 @@ const RecipeList = (props) => {
           }
 
           if (windowWidth < 450) {
-            if (title.length > 4) {
-              titleText = title.slice(0, 4).replace(" ", "") + "..";
-            }
-          } else if (windowWidth < 550) {
             if (title.length > 6) {
-              titleText = title.slice(0, 6).replace(" ", "") + "..";
+              titleText = title.slice(0, 6) + "..";
             }
           } else if (windowWidth < 600) {
             if (title.length > 8) {
@@ -154,7 +150,7 @@ const StSlider = styled(Slider)`
 
   .padding_box {
     min-height: 4.2rem;
-    padding: 1.1rem 2rem 1.2rem;
+    padding: 1.1rem 1.5rem 1.2rem;
 
     & * {
       font-weight: 700;
@@ -168,7 +164,8 @@ const StSlider = styled(Slider)`
   }
 
   .slick-list {
-    width: 85%;
+    width: 100%;
+    max-width: 40rem;
     margin: 0 auto;
     overflow: visible;
   }
@@ -200,6 +197,8 @@ const StRecipeUserInfo = styled.div`
   display: flex;
   align-items: center;
   padding: 1rem;
+  font-size: 1.2rem;
+  font-weight: 700;
 `;
 
 const StProfilePic = styled.div`
@@ -207,8 +206,9 @@ const StProfilePic = styled.div`
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
+  border: 1px solid #b6b6b6;
 
-  margin-right: 0.5rem;
+  margin-right: 1rem;
 
   position: relative;
 

--- a/src/components/recipeMypage/element/RecipeSilder.jsx
+++ b/src/components/recipeMypage/element/RecipeSilder.jsx
@@ -76,17 +76,21 @@ const RecipeList = (props) => {
         {recipeList?.map((recipe, i) => {
           const title = recipe.title;
           let titleText = title;
-          if (title.length > 11) {
-            titleText = title.slice(0, 11) + "...";
+          if (title.length > 10) {
+            titleText = title.slice(0, 10) + "..";
           }
 
           if (windowWidth < 450) {
-            if (title.length > 6) {
-              titleText = title.slice(0, 6) + "...";
+            if (title.length > 4) {
+              titleText = title.slice(0, 4).replace(" ", "") + "..";
             }
-          } else if (windowWidth < 500) {
-            if (title.length > 7) {
-              titleText = title.slice(0, 7) + "...";
+          } else if (windowWidth < 550) {
+            if (title.length > 6) {
+              titleText = title.slice(0, 6).replace(" ", "") + "..";
+            }
+          } else if (windowWidth < 600) {
+            if (title.length > 8) {
+              titleText = title.slice(0, 8) + "..";
             }
           }
 
@@ -125,8 +129,8 @@ const RecipeList = (props) => {
 export default RecipeList;
 
 const StSlickBox = styled.div`
-  height: ${(props) => (props.isTitle ? "calc(40vh + 50px)" : "40vh")};
-  border-radius: 16px;
+  height: ${(props) => (props.isTitle ? "calc(40vh + 5.0rem)" : "40vh")};
+  border-radius: 1.6rem;
 
   display: flex;
   flex-flow: column;
@@ -134,11 +138,11 @@ const StSlickBox = styled.div`
 
   overflow: hidden;
 
-  box-shadow: -2px -2px 10px rgba(155, 155, 155, 0.1),
-    3px 3px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: -0.2rem -0.2rem 1rem rgba(155, 155, 155, 0.1),
+    0.3rem 0.3rem 0.8rem rgba(0, 0, 0, 0.1);
 
   .flex_box {
-    height: ${(props) => (props.isTitle ? "calc(100% - 50px)" : "100%")};
+    height: ${(props) => (props.isTitle ? "calc(100% - 5.0rem)" : "100%")};
     display: flex;
     flex-flow: column;
     justify-content: flex-end;
@@ -149,17 +153,17 @@ const StSlider = styled(Slider)`
   background-color: #fff;
 
   .padding_box {
-    min-height: 42px;
-    padding: 11px 20px 12px;
+    min-height: 4.2rem;
+    padding: 1.1rem 2rem 1.2rem;
 
     & * {
       font-weight: 700;
-      font-size: 14px;
+      font-size: 1.4rem;
       padding: 0;
     }
 
     img {
-      width: 18px;
+      width: 1.8rem;
     }
   }
 
@@ -171,7 +175,7 @@ const StSlider = styled(Slider)`
 
   .slick-slide {
     position: relative;
-    padding: 12px;
+    padding: 1.2rem;
   }
 
   .slide {
@@ -189,26 +193,26 @@ const StSlider = styled(Slider)`
 `;
 
 const StCupHeight = styled.div`
-  height: ${(props) => "calc(" + props.cupHeight + "% - 42px)"};
+  height: ${(props) => "calc(" + props.cupHeight + "% - 4.2rem)"};
 `;
 
 const StRecipeUserInfo = styled.div`
   display: flex;
   align-items: center;
-  padding: 10px;
+  padding: 1rem;
 `;
 
 const StProfilePic = styled.div`
   flex: 0 0 auto;
-  width: 30px;
-  height: 30px;
+  width: 3rem;
+  height: 3rem;
   border-radius: 50%;
 
-  margin-right: 5px;
+  margin-right: 0.5rem;
 
   position: relative;
 
-  font-size: 14px;
+  font-size: 1.4rem;
 
   background: #eee url(${(props) => props.prfilePicSrc}) no-repeat center /
     cover;

--- a/src/components/recipeMypage/element/RecipeTitle.jsx
+++ b/src/components/recipeMypage/element/RecipeTitle.jsx
@@ -30,10 +30,10 @@ const RecipeTitle = (props) => {
 export default RecipeTitle;
 
 const StRecipeTitle = styled.div`
-  padding: 12px 0 40px;
+  padding: 1.2rem 0 4rem;
 
   font-weight: 700;
-  font-size: 18px;
+  font-size: 1.8rem;
 
   color: #393939;
 
@@ -51,12 +51,12 @@ const StRecipeTitle = styled.div`
 const StIconSet = styled.div`
   display: flex;
 
-  gap: 10px;
+  gap: 1rem;
 
   .talk_btn {
-    width: 25px;
+    width: 2.5rem;
   }
   .like_btn {
-    width: 29px;
+    width: 2.9rem;
   }
 `;

--- a/src/styles/customLayoutStyle.js
+++ b/src/styles/customLayoutStyle.js
@@ -148,6 +148,7 @@ const CustomFooter = styled.footer`
 
       .contents_area {
         width: 100%;
+        max-width: 60rem;
         height: 9rem;
 
         display: flex;


### PR DESCRIPTION
**PR** : 
- 마이페이지의 리스트, 시안에 맞게 수정
  - 가로길이 수정, 폰트 사이즈 수정, 프로필 이미지에 border추가
- 마이페이지 리스트의 타이틀 글자수 자르는 부분 조정
- 768px
![image](https://user-images.githubusercontent.com/94776135/194231141-4dcaf0b2-a941-4bfe-b275-1c6bdd399610.png)
- 390px (아이폰, 시안)
![image](https://user-images.githubusercontent.com/94776135/194231203-33f12ac1-a0f4-4b64-b6df-5efc19eac65c.png)

---

- 변경 파일
![image](https://user-images.githubusercontent.com/94776135/194231022-02fc06a5-3a5d-4651-b003-0928b667e243.png)

