### PR TITLE
Bugfix 무한스크롤 2번째 요청에서 아이템 중복되는 점 예외처리

### DIFF
--- a/src/components/recipeMain/AllRecipeList.jsx
+++ b/src/components/recipeMain/AllRecipeList.jsx
@@ -8,6 +8,7 @@ import styledLayoutComponents from "../../styles/customLayoutStyle";
 const { CustomFlexListWrap, CustomFlexList } = styledLayoutComponents;
 
 import ConfirmBox from "../elements/modal/ConfirmBox";
+import Ingredient from "./element/Ingredient";
 
 const AllRecipeList = (props) => {
   const { loggedIn } = props;
@@ -39,14 +40,21 @@ const AllRecipeList = (props) => {
       await api(contentType)
         .get(`/recipes?page=${page}&count=12`)
         .then((res) => {
-          setItems([...res.data.recipeList]);
+          if (res.data.isSuccess) {
+            setItems([...res.data.recipeList]);
+          }
+          console.log("첫번째 요청");
+          console.log(res);
         });
     } else {
       await api(contentType)
-        .get(`/recipes?page=${page + 1}&count=6`)
+        .get(`/recipes?page=${page}&count=6`)
         .then((res) => {
+          if (res.data.isSuccess && page !== 2) {
+            setItems([...items, ...res.data.recipeList]);
+          }
+          console.log("n번째 요청");
           console.log(res);
-          setItems([...items, ...res.data.recipeList]);
         });
     }
     setLoading(false);

--- a/src/components/recipeMain/RecipeBody.jsx
+++ b/src/components/recipeMain/RecipeBody.jsx
@@ -22,11 +22,11 @@ const RecipeBody = (props) => {
       const response = await api(contentType)
         .get(`/ranking/weekly-recipe`)
         .then((res) => {
-          console.log(res);
+          // console.log(res);
           setFavRecipe([...res.data.bestRecipeList]);
         });
     } catch (err) {
-      console.log(err);
+      // console.log(err);
     }
   };
 

--- a/src/components/recipeMain/element/RecipeSilder.jsx
+++ b/src/components/recipeMain/element/RecipeSilder.jsx
@@ -69,7 +69,7 @@ const RecipeSlider = (props) => {
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, [windowWidth]);
-  console.log(recipeList);
+  // console.log(recipeList);
 
   // 모달을 보여주는 state.
   const [needLogginModal, setNeedLogginModal] = useState(false);


### PR DESCRIPTION
**PR** : 
### 수정된 버그 내용

- /api/recipes?page=1&count=12의 response에서 아이템 7개 받아오는 점 수정됨

### 추가로 발견된 내용

- 현재 api응답 시,
  - 첫번째 요청에서 0~11번째 아이템
  - 두번째 요청에서 5~11번째 아이템
  - 세번째 요청에서 12~19번째 아이템을 받아옵니다.
- 때문에 2번쨰 요청의 5~11번째 아이템이 겹쳐서 출력되는 현상이 있습니다. 기존 코드를 작성할 때, page+1를 하여 해결된 것으로 보였는데, 다음과 같이 요청했기 때문에, 클라이언트 단에서는 똑같은 결과를 출력할 수 있었지만 page에는 오류가 보입니다.

![image](https://user-images.githubusercontent.com/94776135/194451324-83717562-361e-43ab-800a-21fc249f13b1.png)

```
변경파일 리스트
```
